### PR TITLE
add shim() function that will upgrade older WAMs to new API interface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 export { default as WebAudioModule } from './WebAudioModule.js';
 export { default as WamParameterInfo } from './WamParameterInfo.js';
 export { default as WamNode } from './WamNode.js';
+
+export { default as shim } from "./shim.js";

--- a/src/shim.js
+++ b/src/shim.js
@@ -1,0 +1,19 @@
+import { WebAudioModule } from "@webaudiomodules/api"
+import { v200_WebAudioModule_shim } from "./shims/v200_imaginary"
+
+/** @param {WebAudioModule} wamInstance */ 
+const shim = (wamInstance) => {
+    switch(wamInstance.descriptor.apiVersion) {
+        case "2.0.0-alpha2":
+            // WAM was built against current SDK, no need to shim
+            return wamInstance
+        case "2.0.0-imaginary":
+            // WAM was built against (a pretend) SDK version 2.0.0-imaginary
+            // for purpose of demonstrating a shim
+            return new v200_WebAudioModule_shim(wamInstance)
+        default:
+            throw new Error(`SDK version ${wamInstance.descriptor.apiVersion} incompatible with host`)
+    }
+}
+
+export default shim

--- a/src/shims/v200_imaginary.js
+++ b/src/shims/v200_imaginary.js
@@ -1,0 +1,77 @@
+import { WebAudioModule } from '@webaudiomodules/api';
+/** @typedef {import('@webaudiomodules/api').WamDescriptor} WamDescriptor */
+/** @typedef {import('@webaudiomodules/api').WamNode} WamNode */
+/** @template T @typedef {import('@webaudiomodules/api').WebAudioModule} IWebAudioModule<T> */
+
+/** @implements {IWebAudioModule<WamNode>} */
+
+export class v200_WebAudioModule_shim {
+    /** @type {import('./v200_types').V200_imaginary.WebAudioModule} */
+    wam
+
+    constructor(wam) {
+        this.wam = wam
+    }
+
+	get isWebAudioModule() {
+		return true;
+	}
+
+	get moduleId() { return this.wam.moduleId }
+
+	get instanceId() { return this.wam.instanceId }
+
+	get descriptor() { 
+        return {...this.wam.descriptor, apiVersion: this.wam.descriptor.sdkVersion}
+    }
+
+	get name() { return this.wam.name }
+
+	get vendor() { return this.wam.vendor; }
+
+	get audioContext() {
+		return this.wam.audioContext;
+	}
+
+	get audioNode() {
+		return this.wam.audioNode;
+	}
+
+	set audioNode(node) {
+		this.wam.audioNode = node;
+	}
+
+	get initialized() {
+		return this.wam.initialized;
+	}
+
+	set initialized(value) {
+		this.wam.initialized = value;
+	}
+
+	/**
+	 * @param {any} [initialState]
+	 * @returns {Promise<WamNode>}
+	 */
+	async createAudioNode(initialState) {
+		return this.wam.createAudioNode(initialState)
+	}
+
+	/**
+	 * @param {any} [state]
+	 * @returns {Promise<WebAudioModule>}
+	 */
+	async initialize(state) {
+		this.wam.initialize(state)
+        return this
+	}
+
+	/**
+	 * @returns {Promise<HTMLElement>}
+	 */
+	async createGui() {
+		return this.wam.createGui()
+	}
+
+	destroyGui() {}
+}

--- a/src/shims/v200_types.d.ts
+++ b/src/shims/v200_types.d.ts
@@ -1,0 +1,71 @@
+import { WamNode } from "@webaudiomodules/api";
+
+// in the shims/types, we put a copy of the original types for older API versions
+// that have been changed in newer APIs
+export namespace V200_imaginary {
+
+    export type WamIODescriptor = Record<`has${'Audio' | 'Midi' | 'Sysex' | 'Osc' | 'Mpe' | 'Automation'}${'Input' | 'Output'}`, boolean>;
+
+    export interface WamDescriptor extends WamIODescriptor {
+        name: string;
+        vendor: string;
+        version: string;
+        sdkVersion: string;
+        thumbnail: string;
+        keywords: string[];
+        isInstrument: boolean;
+        description: string;
+        website: string;
+    }
+
+    /**
+     * Main `WebAudioModule` interface,
+     * its constructor should be the `export default` of the ESM of each WAM.
+     *
+     * @template Node type of the `audioNode` property, could be any `AudioNode` that implements `WamNode`
+     */
+    export interface WebAudioModule<Node extends WamNode = WamNode> {
+        /** should return `true` */
+        readonly isWebAudioModule: boolean;
+        /** The `AudioContext` where the plugin's node lives in */
+        audioContext: BaseAudioContext;
+        /** The `AudioNode` that handles audio in the plugin where the host can connect to/from */
+        audioNode: Node;
+        /** This will return true after calling `initialize()`. */
+        initialized: boolean;
+        /** The identifier of the current WAM, composed of vender + name */
+        readonly moduleId: string;
+        /** The unique identifier of the current WAM instance. */
+        readonly instanceId: string;
+        /** The values from `descriptor.json` */
+        readonly descriptor: WamDescriptor;
+        /** The WAM's name */
+        readonly name: string;
+        /** The WAM Vendor's name */
+        readonly vendor: string;
+
+        /**
+         * This async method must be redefined to get `AudioNode` that
+         * will connected to the host.
+         * It can be any object that extends `AudioNode` and implements `WamNode`
+         */
+        createAudioNode(initialState?: any): Promise<WamNode>;
+        /**
+         * The host will call this method to initialize the WAM with an initial state.
+         *
+         * In this method, WAM devs should call `createAudioNode()`
+         * and store its return `AudioNode` to `this.audioNode`,
+         * then set `initialized` to `true` to ensure that
+         * the `audioNode` property is available after initialized.
+         *
+         * These two behaviors are implemented by default in the SDK.
+         *
+         * The WAM devs can also fetch and preload the GUI Element in while initializing.
+         */
+        initialize(state?: any): Promise<WebAudioModule>;
+        /** Redefine this method to get the WAM's GUI as an HTML `Element`. */
+        createGui(): Promise<Element>;
+        /** Clean up an element previously returned by `createGui` */
+        destroyGui(gui: Element): void
+    }
+}


### PR DESCRIPTION
🔴 for discussion still 🔴 

Adds a `shim` function to the SDK.  After instantiating a WAM, hosts can call `shim(wamInstance)` to "upgrade" older WAMs to appear as if they were built with the new API, or throw an error if the WAM was built with an API version that this API knows nothing about (for example, a newer API).

So far, this can shim the host's mainthread perspective of the old, loaded WAM.  Still to do:
- [ ] shim the audiothread-side host's view of the older WAM to look like a newer WAM
- [ ] shim the older WAM's view of WamEnv to look like the *older* WamEnv interface.  

In order to do shim the older WAM's view of WamEnv, some sub-tasks:
- [ ] WAMs will no longer have access to the global WamEnv instance (or else there's no way to shim it for older WAMs).  Instead the WAM will have to somehow request a reference to WamEnv
- [ ] WamEnv interface will need to be very minimal, for example an older WAM should not be able to get a direct reference to another WAM in the graph or else it can make assumptions that all the WAMs in the graph are ALSO *old* WAMs, and we won't be able to shim those.

I haven't tested this code, still introducing the pattern to hopefully gain agreement that we need backwards compatibility, and either agreement with this approach or a discussion on alternative approaches to solve the same problem.

(I made up API version `v200-imaginary` just to make an example of how the shim could work)