### PR TITLE
fix: url field

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "module": "dist",
   "bugs": {
-    "url": "https://github.com/%40webaudiomodules/sdk/issues"
+    "url": "https://github.com/webaudiomodules/sdk/issues"
   },
-  "homepage": "https://github.com/%40webaudiomodules/sdk#readme"
+  "homepage": "https://github.com/webaudiomodules/sdk#readme"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/%40webaudiomodules/sdk.git"
+    "url": "git+https://github.com/webaudiomodules/sdk.git"
   },
   "scriptPreprocessor": "node_modules/babel-jest",
   "devDependencies": {


### PR DESCRIPTION
remove whitespace in links, including link that is currently dead on https://www.npmjs.com/package/@webaudiomodules/sdk